### PR TITLE
update call to action

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ keywords: Brigade,Kubernetes,CNCF,Kube,Deploy,CI,CD,Pipeline,Scripting,Automatin
     <h1>Event-driven scripting for Kubernetes.</h1>
     <h2>Brigade is a tool for running scriptable, automated tasks in the cloud &mdash; as part of your Kubernetes cluster.</h2>
 
-    <a href="https://github.com/brigadecore/brigade" title="Brigade Github" class="button round primary">Get Brigade</a>
+    <a href="https://docs.brigade.sh/intro/" title="Brigade Github" class="button round primary">Get Started</a>
   </div>
 
 </section>


### PR DESCRIPTION
Changes the `Get Brigade` button to `Get Started` and links to the docs rather than to the repo home.

This is in response to @itowlson 's comment that _"It's not obvious from the repo home page how/where to 'get' Brigade..."_