### PR TITLE
update helm install command

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,9 +281,10 @@
   
   helm install brigade \
   oci://ghcr.io/brigadecore/brigade \
-  --version v2.0.0 \
+  --version v2.3.1 \
   --create-namespace \
-  --namespace brigade
+  --namespace brigade \
+  --wait
   
   <em>// check Brigade status</em>
   helm get all brigade --namespace brigade


### PR DESCRIPTION
v2.3.1 installs much faster and more smoothly, so it's important that this is what we're showing on the landing page. Also tacked on `--wait` for good measure.