### PR TITLE
s/tool/platform/; add missing commas

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   
     <title>Brigade | Event-driven scripting (for Kubernetes)</title>
-    <meta name="description" content="Brigade is a tool for running scriptable automated tasks in the cloud. Brigade runs as part of a Kubernetes cluster.">
+    <meta name="description" content="Brigade is a platform for running scriptable, automated tasks in the cloud. Brigade runs as part of a Kubernetes cluster.">
     <meta name="keywords" content="Brigade,Kubernetes,CNCF,Kube,Deploy,CI,CD,Pipeline,Scripting,Automating,Webhook,Events,k8s,Containers,Helm,Simple,Cloud,Application,App,Brigade.sh">
   
     <!-- twitter card-->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@brigadecore" />
     <meta name="twitter:title" content="Brigade | Event-driven scripting for Kubernetes." />
-    <meta name="twitter:description" content="Brigade is a tool for running scriptable automated tasks in the cloud. Brigade runs as part of a Kubernetes cluster." />
+    <meta name="twitter:description" content="Brigade is a platform for running scriptable, automated tasks in the cloud. Brigade runs as part of a Kubernetes cluster." />
     <meta name="twitter:image" content="https://brigade.sh/logo.png" />
     
     <link rel="icon" type="image/png" href="assets/images/favicon.png">
@@ -127,7 +127,7 @@
     <div class="row fullheight fullwidth" id="intro">
       <div class="columns is-centered">
         <div class="column is-two-thirds">
-          <h1>Brigade is a tool for running
+          <h1>Brigade is a platform for running
             scriptable, automated tasks.</h1>   
         </div>
       </div>


### PR DESCRIPTION
"Platform" captures the scope of Brigade more accurately than "tool."