### PR TITLE
minor correction of some service names

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
   
             <p>Brigade can be used to chain containers together to build processing pipelines.</p>
             <ul class="fancy">
-              <li>Watch for incoming requests from services like GitHub, Docker, and BitBucket</li>
+              <li>Watch for incoming requests from services like GitHub, Docker Hub, and Bitbucket</li>
               <li>Run unit tests, process data, and store results</li>
               <li>Handle events from services like Slack</li>
             </ul>


### PR DESCRIPTION
Minor fixes.

Docker Hub (not Docker) is the service we can listen for events from.

Bitbucket doesn't spell itself with mixed case.